### PR TITLE
Agregando configuración en el back, para soportar remarketing

### DIFF
--- a/app/jobs/remarketing_job.rb
+++ b/app/jobs/remarketing_job.rb
@@ -1,0 +1,46 @@
+class RemarketingJob < ApplicationJob
+  queue_as :medium
+  BATCH_CONVERSATION = 100
+  UNITS = {
+    0 => :minutes,
+    1 => :hours
+  }.freeze
+
+  def perform(inbox)
+    date_time_wait_last_message = inbox.time_wait_last_message.public_send(UNITS[inbox.unit_time]).ago
+    query = inbox.conversations
+            .where(status: [:open, :pending])
+            .where(enabled_remarketing: true)
+            .where(updated_at: 24.hours.ago..date_time_wait_last_message)
+    query.find_each(batch_size: BATCH_CONVERSATION) do |conversation|
+      # 50 request/seconds
+      AgentBots::WebhookJob
+      .set(wait: 0.02.seconds) 
+      .perform_later(inbox.agent_bot.outgoing_url, generate_message_remarketing(inbox, conversation))
+    end
+  end
+
+  private
+  
+  def generate_message_remarketing(inbox,conversation)
+    {
+        account: conversation.account.webhook_data,
+        additional_attributes: {},
+        content_attributes: {},
+        content_type: "text",
+        content: "",
+        active_agent_bot: conversation.active_agent_bot,
+        conversation: conversation.webhook_data,
+        created_at: Time.zone.now,
+        id: nil,
+        inbox: inbox.webhook_data,
+        message_type: :outgoing,
+        message_sub_type: :remarketing,
+        private: false,
+        sender: nil,
+        source_id: nil,
+        behavior_remarketing: inbox.behavior_remarketing,
+        cout_max_remarketing_message: inbox.cout_max_remarketing_message
+    }
+  end
+end

--- a/app/jobs/trigger_scheduled_items_job.rb
+++ b/app/jobs/trigger_scheduled_items_job.rb
@@ -1,11 +1,24 @@
 class TriggerScheduledItemsJob < ApplicationJob
   queue_as :scheduled_jobs
 
+  BATCH_CAMPAIGN = 100
+  BATCH_INBOX    = 100
+
   def perform
     # trigger the scheduled campaign jobs
     Campaign.where(campaign_type: :one_off,
-                   campaign_status: :active).where(scheduled_at: 3.days.ago..Time.current).all.find_each(batch_size: 100) do |campaign|
+                   campaign_status: :active).where(scheduled_at: 3.days.ago..Time.current).all.find_each(batch_size: BATCH_CAMPAIGN) do |campaign|
       Campaigns::TriggerOneoffCampaignJob.perform_later(campaign)
+    end
+
+    # Job Remarketing
+    Inbox.joins(:agent_bot)
+    .where(enabled_remarketing: true)
+    .where.not(agent_bots: { outgoing_url: [nil, ""] })
+    .where.not(time_wait_last_message: [nil])
+    .where.not(unit_time: [nil])
+    .find_each(batch_size: BATCH_INBOX) do |inbox|
+      RemarketingJob.perform_later(inbox)
     end
 
     # Job to reopen snoozed conversations

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -10,6 +10,7 @@
 #  cached_label_list         :text
 #  contact_last_seen_at      :datetime
 #  custom_attributes         :jsonb
+#  enabled_remarketing       :boolean          default(FALSE), not null
 #  first_reply_created_at    :datetime
 #  identifier                :string
 #  justification             :text

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -7,19 +7,24 @@
 #  id                            :integer          not null, primary key
 #  allow_messages_after_resolved :boolean          default(TRUE)
 #  auto_assignment_config        :jsonb
+#  behavior_remarketing          :text
 #  business_name                 :string
 #  channel_type                  :string
+#  cout_max_remarketing_message  :integer          default(0)
 #  csat_survey_enabled           :boolean          default(FALSE)
 #  email_address                 :string
 #  enable_auto_assignment        :boolean          default(TRUE)
 #  enable_email_collect          :boolean          default(TRUE)
+#  enabled_remarketing           :boolean          default(FALSE)
 #  greeting_enabled              :boolean          default(FALSE)
 #  greeting_message              :string
 #  lock_to_single_conversation   :boolean          default(FALSE), not null
 #  name                          :string           not null
 #  out_of_office_message         :string
 #  sender_name_type              :integer          default("friendly"), not null
+#  time_wait_last_message        :integer          default(0)
 #  timezone                      :string           default("UTC")
+#  unit_time                     :integer          default(0)
 #  working_hours_enabled         :boolean          default(FALSE)
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,6 +8,7 @@
 #  content_attributes        :json
 #  content_type              :integer          default("text"), not null
 #  external_source_ids       :jsonb
+#  message_sub_type          :integer          default("none"), not null
 #  message_type              :integer          not null
 #  private                   :boolean          default(FALSE), not null
 #  processed_message_content :text
@@ -80,6 +81,7 @@ class Message < ApplicationRecord
   attr_accessor :echo_id
 
   enum message_type: { incoming: 0, outgoing: 1, activity: 2, template: 3 }
+  enum message_sub_type: { none: 0, remarketing: 1 }, _prefix: :subtype
   enum content_type: {
     text: 0,
     input_text: 1,

--- a/db/migrate/20250813142320_add_enabled_remarketing_to_inboxes.rb
+++ b/db/migrate/20250813142320_add_enabled_remarketing_to_inboxes.rb
@@ -1,0 +1,5 @@
+class AddEnabledRemarketingToInboxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :inboxes, :enabled_remarketing, :boolean, default: false
+  end
+end

--- a/db/migrate/20250815035419_add_fields_remarketing_to_inboxes.rb
+++ b/db/migrate/20250815035419_add_fields_remarketing_to_inboxes.rb
@@ -1,0 +1,8 @@
+class AddFieldsRemarketingToInboxes < ActiveRecord::Migration[7.0]
+  def change
+     add_column :inboxes, :behavior_remarketing, :text
+     add_column :inboxes, :cout_max_remarketing_message, :integer, default: 0
+     add_column :inboxes, :time_wait_last_message, :integer, default: 0
+     add_column :inboxes, :unit_time, :integer, default: 0
+  end
+end

--- a/db/migrate/20250820221118_add_sub_type_to_messages.rb
+++ b/db/migrate/20250820221118_add_sub_type_to_messages.rb
@@ -1,0 +1,5 @@
+class AddSubTypeToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :messages, :message_sub_type, :integer, null: false, default: 0
+  end
+end   

--- a/db/migrate/20250820221512_add_enabled_remarketing_to_conversations.rb
+++ b/db/migrate/20250820221512_add_enabled_remarketing_to_conversations.rb
@@ -1,0 +1,5 @@
+class AddEnabledRemarketingToConversations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :enabled_remarketing, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_08_19_163544) do
+ActiveRecord::Schema[7.0].define(version: 2025_08_20_221512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -502,6 +502,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_19_163544) do
     t.bigint "conversation_sentiment_id"
     t.datetime "last_sentiment_analysis"
     t.boolean "active_agent_bot", default: true, null: false
+    t.boolean "enabled_remarketing", default: false, null: false
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"
@@ -639,6 +640,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_19_163544) do
     t.bigint "portal_id"
     t.integer "sender_name_type", default: 0, null: false
     t.string "business_name"
+    t.boolean "enabled_remarketing", default: false
+    t.text "behavior_remarketing"
+    t.integer "cout_max_remarketing_message", default: 0
+    t.integer "time_wait_last_message", default: 0
+    t.integer "unit_time", default: 0
     t.index ["account_id"], name: "index_inboxes_on_account_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["portal_id"], name: "index_inboxes_on_portal_id"
@@ -733,6 +739,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_19_163544) do
     t.jsonb "additional_attributes", default: {}
     t.text "processed_message_content"
     t.jsonb "sentiment", default: {}
+    t.integer "message_sub_type", default: 0, null: false
     t.index "((additional_attributes -> 'campaign_id'::text))", name: "index_messages_on_additional_attributes_campaign_id", using: :gin
     t.index ["account_id", "created_at", "message_type"], name: "index_messages_on_account_created_type"
     t.index ["account_id", "inbox_id"], name: "index_messages_on_account_id_and_inbox_id"


### PR DESCRIPTION
### ¿Qué hace este PR?
Agrega soporte inicial para remarketing, incluyendo la estructura en tablas y un Job encargado de procesar las notificaciones al agente Bot, todo en la parte del backend

### Cambios realizados
- [x] Migración para agregar atributos adicionales en las tablas inboxes, messages y conversations
- [x] Creacion de un Job remarketing para procesar conversaciones y notificar al agente bot