### PR TITLE
Agregando funcionalidades de task,control expireacion cuenta, validacion crear campaña y migracion para agregar atributo en conversacion para clasificadores

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -1,10 +1,11 @@
 class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   include Api::V1::InboxesHelper
-  before_action :fetch_inbox, except: [:index, :create]
+  before_action :fetch_inbox, except: [:index, :create, :conversation_state_inboxes]
   before_action :fetch_agent_bot, only: [:set_agent_bot]
   before_action :validate_limit, only: [:create]
   # we are already handling the authorization in fetch inbox
   before_action :check_authorization, except: [:show]
+  skip_before_action :authenticate_user!, only: [:conversation_state_inboxes]
 
   def index
     @inboxes = policy_scope(Current.account.inboxes.order_by_name.includes(:channel, { avatar_attachment: [:blob] }))
@@ -65,6 +66,11 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   def destroy
     ::DeleteObjectJob.perform_later(@inbox, Current.user, request.ip) if @inbox.present?
     render status: :ok, json: { message: I18n.t('messages.inbox_deletetion_response') }
+  end
+
+  def conversation_state_inboxes
+    inbox = Current.account.inboxes.find(params[:id])
+    @conversation_states = inbox.conversation_states
   end
 
   def sync_conversation_state_inboxes

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def update
-    @account.assign_attributes(account_params.slice(:name, :locale, :domain, :support_email, :auto_resolve_duration))
+    @account.assign_attributes(account_params.slice(:name, :locale, :domain, :support_email, :auto_resolve_duration,:status))
     @account.custom_attributes.merge!(custom_attributes_params)
     @account.logo.attach(params[:logo]) if params[:logo].present?
     @account.custom_attributes['onboarding_step'] = 'invite_team' if @account.custom_attributes['onboarding_step'] == 'account_update'
@@ -84,7 +84,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def account_params
-    params.permit(:account_name, :email, :name, :password, :locale, :domain, :support_email, :auto_resolve_duration, :user_full_name)
+    params.permit(:account_name, :email, :name, :password, :locale, :domain, :support_email, :auto_resolve_duration, :user_full_name,:status)
   end
 
   def custom_attributes_params

--- a/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
@@ -278,7 +278,9 @@ export default {
     },
     async analizeSuspendedAccount() {
       const { expires_at } = this.getAccount(this.accountId);
-      this.expires_at = this.expires_at ?? expires_at;
+      if (!expires_at)
+        return
+      this.expires_at = expires_at;
       try {
         if (new Date(this.expires_at) <= new Date()) {
           await this.$store.dispatch('accounts/update', { status: "suspended" });

--- a/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
+++ b/app/javascript/dashboard/components/layout/sidebarComponents/Secondary.vue
@@ -49,7 +49,16 @@ export default {
   },
   data() {
     return {
-      expires_at: undefined
+      expires_at: undefined,
+      timer: null,
+      now: new Date(),
+      accountExpired: false
+    }
+  },
+  watch: {
+    accountExpired(expire) {
+      if(!expire) return
+      this.analizeSuspendedAccount()
     }
   },
   computed: {
@@ -228,15 +237,18 @@ export default {
       };
     },
     formattedRemainingTime() {
+      if(this.accountExpired)
+        return this.$t('GENERAL.ACCOUNT.EXPIRE.MESSAGE')
       if (!this.expires_at)
         return this.$t('GENERAL.ACCOUNT.EXPIRE.DATE', { day: "-", hour: "-", minute: "-" })
-      const now = new Date()
       const expires = new Date(this.expires_at)
-      if (expires <= now)
-        return this.$t('GENERAL.ACCOUNT.EXPIRE.MESSAGE')
-      const day = differenceInDays(expires, now)
-      const hour = differenceInHours(expires, now) % 24
-      const minute = differenceInMinutes(expires, now) % 60
+      if (expires <= this.now) {
+        this.accountExpired = true
+        return
+      }
+      const day = differenceInDays(expires, this.now)
+      const hour = differenceInHours(expires, this.now) % 24
+      const minute = differenceInMinutes(expires, this.now) % 60
       return this.$t('GENERAL.ACCOUNT.EXPIRE.DATE', { day, hour, minute })
     }
   },
@@ -250,13 +262,42 @@ export default {
     showNewLink(featureFlag) {
       return this.isFeatureEnabledonAccount(this.accountId, featureFlag);
     },
-    initializeAccount() {
+    initTimer() {
+      let minute = 1000 * 60
+      if (this.timer)
+        return
+      this.timer = setInterval(() => {
+        this.now = new Date()
+      }, minute)
+    },
+    cleanTimer() {
+      if (!this.timer)
+        return
+      clearInterval(this.timer)
+      this.timer = null
+    },
+    async analizeSuspendedAccount() {
       const { expires_at } = this.getAccount(this.accountId);
-      this.expires_at = expires_at
+      this.expires_at = this.expires_at ?? expires_at;
+      try {
+        if (new Date(this.expires_at) <= new Date()) {
+          await this.$store.dispatch('accounts/update', { status: "suspended" });
+          window.location.reload();
+        }
+      } catch (error) {
+        console.warn({ error })
+      }
+    },
+    initializeAccount() {
+      this.analizeSuspendedAccount()
     }
   },
   mounted() {
     this.initializeAccount()
+    this.initTimer()
+  },
+  beforeDestroy() { 
+    this.cleanTimer()
   }
 };
 </script>

--- a/app/javascript/dashboard/components/widgets/EmptyState.vue
+++ b/app/javascript/dashboard/components/widgets/EmptyState.vue
@@ -3,6 +3,7 @@ export default {
   props: {
     title: { type: String, default: '' },
     message: { type: String, default: '' },
+    link: { type: Object, default: { url: "", message: "" } },
   },
 };
 </script>
@@ -20,6 +21,7 @@ export default {
       class="block text-center text-slate-500 dark:text-slate-400 my-4 mx-auto w-[90%]"
     >
       {{ message }}
+      <a :href="link.url">{{ link.message }}</a>
     </p>
     <slot />
   </div>

--- a/app/javascript/dashboard/i18n/locale/en/settings.json
+++ b/app/javascript/dashboard/i18n/locale/en/settings.json
@@ -195,7 +195,8 @@
     "EMAIL_VERIFICATION_SENT": "Verification email has been sent. Please check your inbox.",
     "ACCOUNT_SUSPENDED": {
       "TITLE": "Account Suspended",
-      "MESSAGE": "Your account is suspended. Please reach out to the support team for more information."
+      "MESSAGE": "Your account is suspended. Contact our team at {phone} for more information.",
+      "LINK": "Click here"
     }
   },
   "COMPONENTS": {

--- a/app/javascript/dashboard/i18n/locale/es/settings.json
+++ b/app/javascript/dashboard/i18n/locale/es/settings.json
@@ -195,7 +195,8 @@
     "EMAIL_VERIFICATION_SENT": "El correo electrónico de verificación ha sido enviado. Por favor, comprueba tu bandeja de entrada.",
     "ACCOUNT_SUSPENDED": {
       "TITLE": "Cuenta suspendida",
-      "MESSAGE": "Tu cuenta está suspendida. Comuníquese con el equipo de soporte para obtener más información."
+      "MESSAGE": "Tu cuenta está suspendida. Comuníquese con nuestro equipo al numero {phone} para obtener mayor informacion",
+      "LINK": "Click aqui"
     }
   },
   "COMPONENTS": {

--- a/app/javascript/dashboard/routes/dashboard/settings/campaigns/AddCampaign.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/campaigns/AddCampaign.vue
@@ -41,7 +41,10 @@ export default {
       senderList: [],
       listDesign,
       design: listDesign.DEFAULT,
-      template: undefined
+      template: undefined,
+      loading: {
+        campaign: false
+      }
     };
   },
 
@@ -130,6 +133,9 @@ export default {
       if (!selectedInbox) return false
       const enabledTypes = [INBOX_TYPES.WHATSAPP]
       return enabledTypes.includes(selectedInbox.channel_type)
+    },
+    isLoadingCampaign() {
+      return this.uiFlags.isCreating || this.loading.campaign;
     }
   },
   watch: {
@@ -193,6 +199,7 @@ export default {
     async addCampaign() {
       if (!await this.validateForm())
         return
+      this.loading.campaign = true
       try {
         const campaignDetails = this.getCampaignDetails();
         await this.$store.dispatch('campaigns/create', campaignDetails);
@@ -209,6 +216,7 @@ export default {
           error?.response?.message || this.$t('CAMPAIGN.ADD.API.ERROR_MESSAGE');
         useAlert(errorMessage);
       }
+      this.loading.campaign = false
     },
     async validateForm() {
       let subFormValidate
@@ -471,7 +479,7 @@ export default {
       </div>
 
       <div class="flex flex-row justify-end w-full gap-2 px-0 py-2">
-        <woot-button :is-loading="uiFlags.isCreating">
+        <woot-button :is-loading="isLoadingCampaign">
           {{ $t('CAMPAIGN.ADD.CREATE_BUTTON_TEXT') }}
         </woot-button>
         <woot-button variant="clear" @click.prevent="onClose">

--- a/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/suspended/Index.vue
@@ -24,7 +24,8 @@ onMounted(() => {
   <div class="items-center bg-slate-50 flex justify-center h-full w-full">
     <EmptyState
       :title="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.TITLE')"
-      :message="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.MESSAGE')"
+      :message="$t('APP_GLOBAL.ACCOUNT_SUSPENDED.MESSAGE',{ phone:'+591 61332756' })"
+      :link="{ url:'https://wa.me/59161332756', message: $t('APP_GLOBAL.ACCOUNT_SUSPENDED.LINK')}"
     />
   </div>
 </template>

--- a/app/javascript/dashboard/store/modules/accounts.js
+++ b/app/javascript/dashboard/store/modules/accounts.js
@@ -68,8 +68,8 @@ export const actions = {
     commit(types.default.SET_ACCOUNT_UI_FLAG, { isUpdating: true });
     try {
       const response = await AccountAPI.update('', updateObj);
-      const { logo, id } = response.data
-      commit(types.default.EDIT_ACCOUNT_ID, { id, logo });
+      const { logo, id, status } = response.data
+      commit(types.default.EDIT_ACCOUNT_ID, { id, logo, status });
       commit(types.default.SET_ACCOUNT_UI_FLAG, { isUpdating: false });
     } catch (error) {
       commit(types.default.SET_ACCOUNT_UI_FLAG, { isUpdating: false });

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,42 +2,43 @@
 #
 # Table name: conversations
 #
-#  id                        :integer          not null, primary key
-#  active_agent_bot          :boolean          default(TRUE), not null
-#  additional_attributes     :jsonb
-#  agent_last_seen_at        :datetime
-#  assignee_last_seen_at     :datetime
-#  cached_label_list         :text
-#  contact_last_seen_at      :datetime
-#  custom_attributes         :jsonb
-#  enabled_remarketing       :boolean          default(FALSE), not null
-#  first_reply_created_at    :datetime
-#  identifier                :string
-#  justification             :text
-#  last_activity_at          :datetime         not null
-#  last_activity_incoming_at :datetime
-#  last_activity_outgoing_at :datetime
-#  last_sentiment_analysis   :datetime
-#  priority                  :integer
-#  score                     :float
-#  snoozed_until             :datetime
-#  status                    :integer          default("open"), not null
-#  uuid                      :uuid             not null
-#  waiting_since             :datetime
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  account_id                :integer          not null
-#  assignee_id               :integer
-#  campaign_id               :bigint
-#  contact_id                :bigint
-#  contact_inbox_id          :bigint
-#  conversation_sentiment_id :bigint
-#  conversations_state_id    :integer
-#  display_id                :integer          not null
-#  inbox_id                  :integer          not null
-#  kanban_states_id          :integer
-#  sla_policy_id             :bigint
-#  team_id                   :bigint
+#  id                               :integer          not null, primary key
+#  active_agent_bot                 :boolean          default(TRUE), not null
+#  additional_attributes            :jsonb
+#  agent_last_seen_at               :datetime
+#  assignee_last_seen_at            :datetime
+#  cached_label_list                :text
+#  contact_last_seen_at             :datetime
+#  custom_attributes                :jsonb
+#  enabled_remarketing              :boolean          default(FALSE), not null
+#  first_reply_created_at           :datetime
+#  identifier                       :string
+#  justification                    :text
+#  last_activity_at                 :datetime         not null
+#  last_activity_incoming_at        :datetime
+#  last_activity_outgoing_at        :datetime
+#  last_conversation_state_analysis :datetime
+#  last_sentiment_analysis          :datetime
+#  priority                         :integer
+#  score                            :float
+#  snoozed_until                    :datetime
+#  status                           :integer          default("open"), not null
+#  uuid                             :uuid             not null
+#  waiting_since                    :datetime
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  account_id                       :integer          not null
+#  assignee_id                      :integer
+#  campaign_id                      :bigint
+#  contact_id                       :bigint
+#  contact_inbox_id                 :bigint
+#  conversation_sentiment_id        :bigint
+#  conversations_state_id           :integer
+#  display_id                       :integer          not null
+#  inbox_id                         :integer          not null
+#  kanban_states_id                 :integer
+#  sla_policy_id                    :bigint
+#  team_id                          :bigint
 #
 # Indexes
 #

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -65,4 +65,9 @@ class InboxPolicy < ApplicationPolicy
   def sync_conversation_state_inboxes?
     @account_user.administrator? || @account_user.agent?
   end
+
+  def conversation_state_inboxes?
+    true
+  end
+
 end

--- a/app/views/api/v1/accounts/inboxes/conversation_state_inboxes.json.jbuilder
+++ b/app/views/api/v1/accounts/inboxes/conversation_state_inboxes.json.jbuilder
@@ -1,0 +1,8 @@
+json.payload do
+  json.array! @conversation_states do |state|
+    json.id state.id
+    json.name state.name
+    json.description state.description
+    json.color state.color
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,7 @@ Rails.application.routes.draw do
             get :agent_bot, on: :member
             post :set_agent_bot, on: :member
             delete :avatar, on: :member
+            get :conversation_state_inboxes, on: :member
             post :sync_conversation_state_inboxes, on: :member
           end
           resources :inbox_members, only: [:create, :show], param: :inbox_id do

--- a/db/migrate/20250918154414_add_last_conversation_state_analysis_to_conversations.rb
+++ b/db/migrate/20250918154414_add_last_conversation_state_analysis_to_conversations.rb
@@ -1,0 +1,5 @@
+class AddLastConversationStateAnalysisToConversations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :last_conversation_state_analysis, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_17_170012) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_18_154414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -575,6 +575,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_17_170012) do
     t.boolean "enabled_remarketing", default: false, null: false
     t.datetime "last_activity_outgoing_at"
     t.datetime "last_activity_incoming_at"
+    t.datetime "last_conversation_state_analysis"
     t.index ["account_id", "display_id"], name: "index_conversations_on_account_id_and_display_id", unique: true
     t.index ["account_id", "id"], name: "index_conversations_on_id_and_account_id"
     t.index ["account_id", "inbox_id", "status", "assignee_id"], name: "conv_acid_inbid_stat_asgnid_idx"

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,31 @@
+namespace :storage do
+  TIME_UNITS = {
+    "hours"  => :hour,
+    "days"   => :day,
+    "weeks"  => :week,
+    "months" => :month
+  }.freeze
+  desc "Deletes files of messages older than a certain date"
+  task :clean_file_store_messages, [:time] => :environment do |t, args|
+    # time: ["1.hours","1.days", "1.weeks", "1.months"],
+    value, unit = args[:time].split(".")
+    unless TIME_UNITS[unit]
+      Rails.logger.info "⚠️ Unit Invalid #{unit} use : #{TIME_UNITS.keys.join(", ")}"
+      exit 1
+    end
+    date = value.to_i.public_send(TIME_UNITS[unit]).ago
+    file_deleted = 0
+    file_errors  = 0
+    Attachment.where("created_at < ? ", date).find_each do |attachment|
+      blob = attachment.file.blob rescue nil
+      next unless blob
+      begin
+        blob.service.delete(blob.key)
+        file_deleted += 1
+      rescue => e
+        file_errors += 1
+      end
+    end
+    Rails.logger.info "🎉Files deleted before to #{date} : success: #{file_deleted}, errors: #{file_errors}"
+  end
+end


### PR DESCRIPTION
**¿Qué hace este PR?**
Permite poder mostrar icono por dominios y actualiza características de los planes

**Cambios realizados**

- [x] funcion task para eliminar archivos de las conversaciones dentro de un tiempo, back
- [x] funcion periodica para controlar fecha de expiracion, front y back
- [x] desabilitar button create y agregar loader al momento de crear campaña, front
- [x] validacion de expiracion para cuentas que no tenga fecha definida, front
- [x] migración que agrega atributo analysis_conversation en conversacion para controlar cuando fue la ultima reclasificacion
- [x] agregando endpoint publico para obtener clasificadores por inbox, back